### PR TITLE
mips64: Add setjmp.S into extra_dist

### DIFF
--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -1758,6 +1758,7 @@ module = {
   common = lib/setjmp.S;
   extra_dist = lib/i386/setjmp.S;
   extra_dist = lib/mips/setjmp.S;
+  extra_dist = lib/mips64/setjmp.S;
   extra_dist = lib/x86_64/setjmp.S;
   extra_dist = lib/sparc64/setjmp.S;
   extra_dist = lib/powerpc/setjmp.S;


### PR DESCRIPTION
Or the tarball from "make dist" will lack this file.